### PR TITLE
Add a .gnupg directory for duplicity; .inputrc optionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.3.0
+
+* Add .gnupg directory, to fix bug in duplicity primarily
+* Optionally allow use_vim_editing to install .inputrc
+
 ## Version 1.2.0
 
 * Include 'root' and 'adm' groups for each admin, for read access to logs and configs

--- a/admins/init.sls
+++ b/admins/init.sls
@@ -49,6 +49,22 @@ admin-{{ user}}-key-{{ loop.index0 }}:
     - require:
       - user: admin-{{ user }}
   {% endfor %}
+
+  {% if 'use_vim_editing' in data and data['use_vim_editing'] %}
+/home/{{ user }}/.inputrc:
+  file.managed:
+    - contents: 'set editing-mode vi\n'
+    - mode: 0644
+    - owner: {{ user }}
+  {% endif %}
+
+# 'duplicity' unfortunately will create this with the wrong owner
+# if used with sudo, so make sure it's there with the right owner.
+/home/{{ user }}/.gnupg:
+  file.directory:
+    - mode: 0700
+    - owner: {{ user }}
+
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
The backup/recovery program 'duplicity' has an annoying bug
where it will create .gnupg with the wrong ownership if you recover
with 'sudo'.

This adds the directory with the right ownership, which fixes the
problem.

Also added the optional ability to enable vi editing mode via .inputrc
