### PR TITLE
admins_extra_groups grain for adding groups to admin accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CURRENT
+
+* Allow additional admin groups via admins_extra_groups grain
+
 ## Version 1.3.0
 
 * Add .gnupg directory, to fix bug in duplicity primarily

--- a/admins/init.sls
+++ b/admins/init.sls
@@ -23,6 +23,9 @@ admin-{{ user }}:
       - supervisor
       - adm
       - root
+{% for group in grains.get("admins_extra_groups", []) %}
+      - {{ group }}
+{% endfor %}
     - require:
       - group: supervisor
       - group: wheel


### PR DESCRIPTION
This allows formula to insert their group into the list of groups that admin users are members of.

This in turn then means that we can start to use '2750' permissions on config directories, which makes the system more secure but doesn't annoy us when diagnosing problems, since we can happily read the configs and list directories without using sudo
