### PR TITLE
Allow specification of ad hoc admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.3.2
+
+* Allow application of additional admin groups.
+
 ## Version 1.3.1
 
 * Fix the absent state to remove the user, not admin-jblogs

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 admins-formula
 ==============
 
+Default Behaviour
+=================
+
+By default this state will create admin users as determined by uawea defined in the 'admins' pillar. 
+
 for each user defined in the ``admins`` pillar dict:
 
  - create the user account
@@ -31,3 +36,35 @@ example::
             comment: dekstop2.jo.local
       rogue:
         absent: True
+
+Ad-hoc admin groups
+===================
+
+Additional groups of admins may be specified and applied ad-hoc.
+
+for example, for each user defined in the ``my_adhoc_admins`` pillar dict:
+
+example::
+
+    my_adhoc_admins:
+      username:
+        # Old format with just a single ssh public key
+        key: your_key
+        comment: your key_name, comment
+        enc: ssh-rsa
+      jobloggs:
+        # New format with multiple keys
+        public_keys:
+          - key: AAAAB3n....=
+            enc: ssh-rsa
+            comment: oncall-laptop-1.local
+          - key: AAAAB3n....=
+            enc: ssh-rsa
+            comment: dekstop2.jo.local
+      rogue:
+        absent: True
+
+The above can be applied by invoking the following state.sls call:
+
+> salt-call state.sls admins pillar='{ alternate_admins: \"my_adhoc_admins\" }'"
+

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ admins-formula
 Default Behaviour
 =================
 
-By default this state will create admin users as determined by uawea defined in the 'admins' pillar. 
+By default this state will create admin users as determined by admin users defined in the 'admins' pillar. 
 
 for each user defined in the ``admins`` pillar dict:
 

--- a/admins/map.jinja
+++ b/admins/map.jinja
@@ -1,4 +1,11 @@
+
+{% set admins = salt['pillar.get']('admins',{}) %}
+
+{% if salt['pillar.get']('alternate_admins') %}
+  {% set admins = pillar[pillar['alternate_admins']] %}
+{% endif %}
+
 {% set admins = salt['grains.filter_by']({
     'Debian': {
     },
-}, merge=salt['pillar.get']('admins',{})) %}
+}, merge=admins) %}


### PR DESCRIPTION
This change was required following the need to manage different groups of admin users - some cleared for accessing only certain machines in our pipeline.