### PR TITLE
Option not to add groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 1.x.x
+
+* Add an option to disable adding the user to the admin groups
+
 ## Version 1.3.1
 
 * Fix the absent state to remove the user, not admin-jblogs

--- a/README.rst
+++ b/README.rst
@@ -31,3 +31,13 @@ example::
             comment: dekstop2.jo.local
       rogue:
         absent: True
+
+If you want the user not to get the admin roles you can add ``admin_groups``::
+
+    admins:
+      deploy-user:
+        key: your_key
+        comment: your key_name, comment
+        enc: ssh-rsa
+        admin_groups: False
+

--- a/admins/init.sls
+++ b/admins/init.sls
@@ -19,6 +19,7 @@ admin-{{ user }}:
     - home: /home/{{ user }}
     - shell: /bin/bash
     - order: 1
+  {% if data.get('admin_groups',True) %}
     - groups:
       - wheel
       - supervisor
@@ -27,6 +28,7 @@ admin-{{ user }}:
     - require:
       - group: supervisor
       - group: wheel
+  {% endif %}
   {% for key in data.get("public_keys", []) %}
 
 admin-{{ user}}-key-{{ loop.index0 }}:


### PR DESCRIPTION
This adds a pillar option to not add the user to the admin groups, useful if you want to create a user with just ssh and not root.