### PR TITLE
Fix owner warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UNRELEASED
+
+* Fixes owner warning
+
 ## Version 1.3.1
 
 * Fix the absent state to remove the user, not admin-jblogs

--- a/admins/init.sls
+++ b/admins/init.sls
@@ -56,7 +56,7 @@ admin-{{ user}}-key-{{ loop.index0 }}:
   file.managed:
     - contents: 'set editing-mode vi\n'
     - mode: 0644
-    - owner: {{ user }}
+    - user: {{ user }}
   {% endif %}
 
 # 'duplicity' unfortunately will create this with the wrong owner
@@ -64,7 +64,7 @@ admin-{{ user}}-key-{{ loop.index0 }}:
 /home/{{ user }}/.gnupg:
   file.directory:
     - mode: 0700
-    - owner: {{ user }}
+    - user: {{ user }}
 
 {% endif %}
 


### PR DESCRIPTION
Fixes this:

`out: [WARNING ] Use of argument owner found, "owner" is invalid, please use "user"`