### PR TITLE
Update ownership of homedirectory with those of user just created.

### DIFF
--- a/admins/init.sls
+++ b/admins/init.sls
@@ -27,6 +27,17 @@ admin-{{ user }}:
     - require:
       - group: supervisor
       - group: wheel
+
+admin-{{ user }}-homedirfix:
+   file.directory:
+     - name: /home/{{ user }}
+     - user: {{ user }}
+     - group: {{ user }}
+     - recurse:
+       - user
+       - group
+
+
   {% for key in data.get("public_keys", []) %}
 
 admin-{{ user}}-key-{{ loop.index0 }}:


### PR DESCRIPTION
Useful in situations where a user returns back and the home directory
already exists.